### PR TITLE
Replace `mint.json` with `docs.json`

### DIFF
--- a/almond/development.mdx
+++ b/almond/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to the docs are located (where you can find `docs.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/almond/essentials/navigation.mdx
+++ b/almond/essentials/navigation.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 icon: 'map'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -42,7 +42,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -63,4 +63,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/almond/essentials/settings.mdx
+++ b/almond/essentials/settings.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Global Settings'
-description: 'Mintlify gives you complete control over the look and feel of your documentation using the mint.json file'
+description: 'Mintlify gives you complete control over the look and feel of your documentation using the docs.json file'
 icon: 'gear'
 ---
 
-Every Mintlify site needs a `mint.json` file with the core configuration settings. Learn more about the [properties](#properties) below.
+Every Mintlify site needs a `docs.json` file with the core configuration settings. Learn more about the [properties](#properties) below.
 
 ## Properties
 

--- a/almond/quickstart.mdx
+++ b/almond/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 

--- a/linden/development.mdx
+++ b/linden/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to the docs are located (where you can find `docs.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/linden/essentials/navigation.mdx
+++ b/linden/essentials/navigation.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -41,7 +41,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -62,4 +62,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/linden/quickstart.mdx
+++ b/linden/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 

--- a/maple/development.mdx
+++ b/maple/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to the docs are located (where you can find `docs.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/maple/essentials/navigation.mdx
+++ b/maple/essentials/navigation.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 icon: 'map'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -42,7 +42,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -63,4 +63,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/maple/quickstart.mdx
+++ b/maple/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 

--- a/mint/development.mdx
+++ b/mint/development.mdx
@@ -23,7 +23,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-**Step 2**: Navigate to the docs directory (where the `mint.json` file is located) and execute the following command:
+**Step 2**: Navigate to the docs directory (where the `docs.json` file is located) and execute the following command:
 
 ```bash
 mintlify dev

--- a/mint/essentials/navigation.mdx
+++ b/mint/essentials/navigation.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 icon: 'map'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -42,7 +42,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -63,4 +63,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/mint/quickstart.mdx
+++ b/mint/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 

--- a/palm/development.mdx
+++ b/palm/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to the docs are located (where you can find `docs.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/palm/essentials/navigation.mdx
+++ b/palm/essentials/navigation.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 icon: 'map'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -42,7 +42,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -63,4 +63,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/palm/quickstart.mdx
+++ b/palm/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 

--- a/willow/development.mdx
+++ b/willow/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to the docs are located (where you can find `docs.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/willow/essentials/navigation.mdx
+++ b/willow/essentials/navigation.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Navigation'
-description: 'The navigation field in mint.json defines the pages that go in the navigation menu'
+description: 'The navigation field in docs.json defines the pages that go in the navigation menu'
 icon: 'map'
 ---
 
 The navigation menu is the list of links on every website.
 
-You will likely update `mint.json` every time you add a new page. Pages do not show up automatically.
+You will likely update `docs.json` every time you add a new page. Pages do not show up automatically.
 
 ## Navigation syntax
 
@@ -42,7 +42,7 @@ Our navigation syntax is recursive which means you can make nested navigation gr
 
 ## Folders
 
-Simply put your MDX files in folders and update the paths in `mint.json`.
+Simply put your MDX files in folders and update the paths in `docs.json`.
 
 For example, to have a page at `https://yoursite.com/your-folder/your-page` you would make a folder called `your-folder` containing an MDX file called `your-page.mdx`.
 
@@ -63,4 +63,4 @@ You cannot use `api` for the name of a folder unless you nest it inside another 
 
 ## Hidden Pages
 
-MDX files not included in `mint.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.
+MDX files not included in `docs.json` will not show up in the sidebar but are accessible through the search bar and by linking directly to them.

--- a/willow/quickstart.mdx
+++ b/willow/quickstart.mdx
@@ -24,7 +24,7 @@ Learn how to update your docs locally and and deploy them to the public.
     [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the
     documentation changes locally with this command: ``` npm i -g mintlify ```
     2. Run the following command at the root of your documentation (where
-    `mint.json` is): ``` mintlify dev ```
+    `docs.json` is): ``` mintlify dev ```
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
This PR replaces `mint.json` with `docs.json` in the theme preview pages.